### PR TITLE
Change setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7.4-slim as builder
 
+ARG PYTHON_ENV=production
+ENV PYTHON_ENV=${PYTHON_ENV}
+
 RUN apt-get -yqq update \
 && apt-get -yqq install gcc
 
@@ -22,6 +25,7 @@ COPY requirements.txt /app/requirements.txt
 RUN pip3 install -r requirements.txt --find-links /wheels
 
 COPY . /app
+
 ENV PYTHONPATH /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.7.4-slim as builder
 
 ARG PYTHON_ENV=production
-ENV PYTHON_ENV=${PYTHON_ENV}
+ARG API_KEY
 
-RUN apt-get -yqq update \
-&& apt-get -yqq install gcc
+ENV PYTHON_ENV=${PYTHON_ENV}
+ENV API_KEY=${API_KEY}
 
 WORKDIR /app
 
@@ -12,11 +12,6 @@ COPY requirements.txt /app/requirements.txt
 RUN pip3 wheel -r requirements.txt -w /wheels
 
 FROM python:3.7.4-slim
-RUN apt-get -yqq update \
-&& apt-get -yqq install gcc curl unzip \
-&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-&& unzip awscliv2.zip \
-&& ./aws/install --update
 
 WORKDIR /app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,59 +1,22 @@
-properties([
-  pipelineTriggers([cron('00 * * * *')]),
-  disableConcurrentBuilds(),
-  buildDiscarder(logRotator(numToKeepStr: '10'))
-])
+@Library('podTemplateLib')
 
-podTemplate(label: 'docker', containers: [
-  containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat', envVars: [
-    envVar(key: 'DOCKER_HOST', value: 'tcp://docker-host-docker-host:2375')
-  ])
-])
-{
-  node('docker') {
-    stage('Build and publish image') {
-      container('docker') {
+import net.santiment.utils.podTemplates
+
+slaveTemplates = new podTemplates()
+
+slaveTemplates.dockerTemplate { label ->
+  node(label) {
+    container('docker') {
+      withCredentials([
+        string(credentialsId: 'discord_webhook', variable: 'DISCORD_WEBHOOK'),
+        string(credentialsId: 'sanbase_api_key', variable: 'API_KEY'),
+      ]) {
+
         def scmVars = checkout scm
+        def imageName = "api-tests"
 
-        withCredentials([string(credentialsId: 'aws_account_id', variable: 'aws_account_id')]) {
-          def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
-          docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
-            sh "docker build -t ${awsRegistry}/api-tests:${env.BRANCH_NAME} -t ${awsRegistry}/api-tests:${scmVars.GIT_COMMIT} ."
-            sh "docker push ${awsRegistry}/api-tests:${env.BRANCH_NAME}"
-            sh "docker push ${awsRegistry}/api-tests:${scmVars.GIT_COMMIT}"
-          }
-        }
-      }
-    }
-  }
-}
-
-podTemplate(label: 'api-tests', containers: [
-  containerTemplate(name: 'api-tests',
-                    image: "913750763724.dkr.ecr.eu-central-1.amazonaws.com/api-tests:${env.BRANCH_NAME}",
-                    ttyEnabled: true,
-                    command: 'cat',
-                    envVars: [envVar(key: 'TOP_PROJECTS_BY_MARKETCAP', value: '100')]
-  )
-])
-{
-  node('api-tests') {
-    stage('Run tests') {
-      container('api-tests') {
-        withCredentials([
-          string(credentialsId: 'discord_webhook', variable: 'DISCORD_WEBHOOK'),
-          string(credentialsId: 'sanbase_api_key', variable: 'API_KEY'),
-          [
-            $class: 'AmazonWebServicesCredentialsBinding',
-            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-            credentialsId: 's3_api-tests-json',
-            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-          ]
-        ])
-
-        {
-          sh 'ls /app'
-          RUN_STATUS = sh(script: "python /app/cli.py sanity", returnStatus: true)
+        stage('Run tests') {
+          RUN_STATUS = sh(script: "./bin/test.sh", returnStatus: true)
 
           if (RUN_STATUS != 0) {
             discordSend (
@@ -68,20 +31,20 @@ podTemplate(label: 'api-tests', containers: [
             )
             currentBuild.result = 'FAILURE'
           }
-          else {
-            publishHTML (
-              target: [
-                allowMissing: false,
-                alwaysLinkToLastBuild: false,
-                keepAll: true,
-                reportDir: 'output',
-                reportFiles: 'index.html, output.json',
-                reportName: "Test Report"
-            ])
-            sh "aws s3 cp output/output.json s3://api-tests-json/latest_report.json --acl public-read"
-            sh "aws s3 cp output/index.html s3://api-tests-json/latest_report.html --acl public-read"
-            sh "aws s3 cp output/output.json s3://api-tests-json/output-${BUILD_NUMBER}.json --acl public-read"
-            sh "aws s3 cp output/output_stable.json s3://api-tests-json/latest_report_stable.json --acl public-read"
+        }
+      }
+
+      stage('Build image') {
+        withCredentials([string(credentialsId: 'aws_account_id', variable: 'aws_account_id')]) {
+          def awsRegistry = "${env.aws_account_id}.dkr.ecr.eu-central-1.amazonaws.com"
+
+          docker.withRegistry("https://${awsRegistry}", "ecr:eu-central-1:ecr-credentials") {
+            sh "docker build \
+              -t ${awsRegistry}/${imageName}:${env.BRANCH_NAME} \
+              -t ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT} \
+              -f docker/Dockerfile ."
+            sh "docker push ${awsRegistry}/${imageName}:${env.BRANCH_NAME}"
+            sh "docker push ${awsRegistry}/${imageName}:${scmVars.GIT_COMMIT}"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ slaveTemplates.dockerTemplate { label ->
     container('docker') {
       withCredentials([
         string(credentialsId: 'discord_webhook', variable: 'DISCORD_WEBHOOK'),
-        string(credentialsId: 'sanbase_api_key', variable: 'API_KEY'),
+        string(credentialsId: 'sanbase_api_key', variable: 'API_KEY')
       ]) {
 
         def scmVars = checkout scm

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,8 @@ requests = "==2.22.0"
 "discord.py" = "==1.2.3"
 s3fs = "==0.4.2"
 fire = "==0.2.1"
+boto3 = "==1.14.25"
+python-dotenv = "==0.10.3"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ced9f869dda54b7811c8d993258987c195ffdc3258a6de0fabc9f63de4fa98d8"
+            "sha256": "890a1d95537d8f9b3fbabaaf737afb34ae73a2f34e9819da114fe174dd7f9ac8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,12 +57,19 @@
             ],
             "version": "==19.3.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:69038d4a42056ec67060020a64001ac09a6ef668aca81c45af1cbbdb7b56a4f6"
+            ],
+            "index": "pypi",
+            "version": "==1.14.25"
+        },
         "botocore": {
             "hashes": [
-                "sha256:9c4694e413c344ca2fb1175f33a97265dbf7f8a5943fbeafde3161d080b72308",
-                "sha256:fcbcda16c815744482be4206ed098f4d08f2dfddfb1fcfa0f822f4cfd94adb85"
+                "sha256:918c5ccde335545a2c2eb426bc47520a960d11e3e3ab72aa43b73f1d692f07e1",
+                "sha256:98dc8b99e47d2d0bc14c017c957b4fb23172d2fc7db5e8529576308a6898f0fc"
             ],
-            "version": "==1.17.21"
+            "version": "==1.17.25"
         },
         "certifi": {
             "hashes": [
@@ -162,24 +169,29 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:006413f08ba5db1f5b1e0d6fbdc2ac9058b062ccf552f57182563a78579c34b4",
-                "sha256:1ab264770e7cf2cf4feb99f22c737066aef21ddf1ec402dc255450ac15eacb7b",
-                "sha256:20bcd11efe194cd302bd0653cb025b8d16bcd80442359bfca8d49dc805f35ec8",
-                "sha256:2a6d64336b547e25730b6221e7aadfb01a391a065d43b5f51f0b9d7f673d2dd2",
-                "sha256:31d32c83bb2b617377c6156f75e88b9ec2ded289e47ad4ff0f263dc1019d88b1",
-                "sha256:3d77a6630d093d74cbbfebaa0571d00790966be1ed204e4a8239f5cbd6835c5d",
-                "sha256:4416825ebc9c1f135027a30e8d8aea0edcf45078ce767c7f7386737413cfb98f",
-                "sha256:465c752278d27895e23f1379d6fcfa3a2990643b803c25e3bc16a10641d2346a",
-                "sha256:647cf232ccf6265d2ba1ac4103e8c8b6ac7b03a40da3421234ffb03dda217f59",
-                "sha256:67065d938df34478451af62fbd0670d2b51c4d859fb66673064eb5de8660dd7c",
-                "sha256:81de040403a33bf3c68e9d4a40e26c8d24da00f7e3fadd845003b7e106785da7",
-                "sha256:894dd47c0a6ce38dc19bc87d1f7e2b0608310b2a18d1572291157450b05ce874",
-                "sha256:91c153f4318e3c67c035fd1185f5ea2613f15008b73b66985033033f6fe54bbd",
-                "sha256:a47abc48c7b81fe6e636dde8a58e49b13d87d140e0f448213a4879f4a3f73345",
-                "sha256:a68e42e22f7fd190a532e4215e142276970c2d54040a0c46842fcb3db8b6ec5b",
-                "sha256:da06fa530591a141ffbe1712bbeec784734c3436b40c942d21652f305199b5d9"
+                "sha256:09b4096748178bcc764b81587b00ab720eac24965d2bf44ecbe09dcf4e8ed253",
+                "sha256:19cf4db0272da286863a50406f6430101af129f288c421b1a7f33ddfc8d0180f",
+                "sha256:244a9088140a4c540e0a2db9c8ada5ad12520efded592a46e5bc43ff8f0fd0aa",
+                "sha256:24e8db94948019d531ce0bcd637ac24b1c8f6744ac86d2aa0eb6dbaeb1386f82",
+                "sha256:2a9d10930406748b50f60c5fa74c399a1c1080aa6ce6e3fe5f38473b02f6f06d",
+                "sha256:605e4d43b421524ad955a56535391e02866d07bce27c644e2c99e25fb59d63d1",
+                "sha256:695b4165520bdfe381d15a6db03778babb265fee7affdc43e169a881f3f329bc",
+                "sha256:6aa7ea00ad7d898704ffed46e83efd7ec985beba57f507c957979f080678b9ea",
+                "sha256:7c9adba58a67d23cc131c4189da56cb1d0f18a237c43188d831a44e4fc5df15a",
+                "sha256:7ce8f5364c74aac06abad84d8744d659bd86036e86c4ebf14c75ae4292597b46",
+                "sha256:855bb281f3cc8e23ef66064a2beb229674fdf785638091fc82a172e3e84c2780",
+                "sha256:9ccc651261b7044ffc3b1e2f9af17b1ef4c6a12fc080b5a7353ef0b53a50be28",
+                "sha256:b0786ac32983191fcd9cc0230b4ec2f8b3c25dee9beca46ca506c5d6cc5c593d",
+                "sha256:bf8d527a2eb9a5db1c9e5e405d1b1c4e66be983620c9ce80af6aae430d9a0c9c",
+                "sha256:c06ea133b44805d42f2507cb3503f6647b0c7918f1900b5063f5a8a69c63f6d2",
+                "sha256:c1f850908600efa60f81ad14eedbaf7cb17185a2c6d26586ae826ae5ce21f6e0",
+                "sha256:cef05e9a2302f96d6f0666ee70ac7715cbc12e3802d8b8eb80bacd6ab81a0a24",
+                "sha256:e3868686f3023644523df486fc224b0af4349f3cdb933b0a71f261a574d7b65f",
+                "sha256:ebb6168c9330309b1f3360d36c481d8cd621a490cf2a69c9d6625b2a76777c12",
+                "sha256:f74c39621b03cec7bc08498f140192ac26ca940ef20beac6dfad3714d2298b2a",
+                "sha256:f9753c6292d5a1fe46828feb38d1de1820e3ea109a5fea0b6ea1dca6e9d0b220"
             ],
-            "version": "==3.2.2"
+            "version": "==3.3.0"
         },
         "multidict": {
             "hashes": [
@@ -205,34 +217,34 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:13af0184177469192d80db9bd02619f6fa8b922f9f327e077d6f2a6acb1ce1c0",
-                "sha256:26a45798ca2a4e168d00de75d4a524abf5907949231512f372b217ede3429e98",
-                "sha256:26f509450db547e4dfa3ec739419b31edad646d21fb8d0ed0734188b35ff6b27",
-                "sha256:30a59fb41bb6b8c465ab50d60a1b298d1cd7b85274e71f38af5a75d6c475d2d2",
-                "sha256:33c623ef9ca5e19e05991f127c1be5aeb1ab5cdf30cb1c5cf3960752e58b599b",
-                "sha256:356f96c9fbec59974a592452ab6a036cd6f180822a60b529a975c9467fcd5f23",
-                "sha256:3c40c827d36c6d1c3cf413694d7dc843d50997ebffbc7c87d888a203ed6403a7",
-                "sha256:4d054f013a1983551254e2379385e359884e5af105e3efe00418977d02f634a7",
-                "sha256:63d971bb211ad3ca37b2adecdd5365f40f3b741a455beecba70fd0dde8b2a4cb",
-                "sha256:658624a11f6e1c252b2cd170d94bf28c8f9410acab9f2fd4369e11e1cd4e1aaf",
-                "sha256:76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598",
-                "sha256:7b57f26e5e6ee2f14f960db46bd58ffdca25ca06dd997729b1b179fddd35f5a3",
-                "sha256:7b852817800eb02e109ae4a9cef2beda8dd50d98b76b6cfb7b5c0099d27b52d4",
-                "sha256:8cde829f14bd38f6da7b2954be0f2837043e8b8d7a9110ec5e318ae6bf706610",
-                "sha256:a2e3a39f43f0ce95204beb8fe0831199542ccab1e0c6e486a0b4947256215632",
-                "sha256:a86c962e211f37edd61d6e11bb4df7eddc4a519a38a856e20a6498c319efa6b0",
-                "sha256:a8705c5073fe3fcc297fb8e0b31aa794e05af6a329e81b7ca4ffecab7f2b95ef",
-                "sha256:b6aaeadf1e4866ca0fdf7bb4eed25e521ae21a7947c59f78154b24fc7abbe1dd",
-                "sha256:be62aeff8f2f054eff7725f502f6228298891fd648dc2630e03e44bf63e8cee0",
-                "sha256:c2edbb783c841e36ca0fa159f0ae97a88ce8137fb3a6cd82eae77349ba4b607b",
-                "sha256:cbe326f6d364375a8e5a8ccb7e9cd73f4b2f6dc3b2ed205633a0db8243e2a96a",
-                "sha256:d34fbb98ad0d6b563b95de852a284074514331e6b9da0a9fc894fb1cdae7a79e",
-                "sha256:d97a86937cf9970453c3b62abb55a6475f173347b4cde7f8dcdb48c8e1b9952d",
-                "sha256:dd53d7c4a69e766e4900f29db5872f5824a06827d594427cf1a4aa542818b796",
-                "sha256:df1889701e2dfd8ba4dc9b1a010f0a60950077fb5242bb92c8b5c7f1a6f2668a",
-                "sha256:fa1fe75b4a9e18b66ae7f0b122543c42debcf800aaafa0212aaff3ad273c2596"
+                "sha256:082f8d4dd69b6b688f64f509b91d482362124986d98dc7dc5f5e9f9b9c3bb983",
+                "sha256:1bc0145999e8cb8aed9d4e65dd8b139adf1919e521177f198529687dbf613065",
+                "sha256:309cbcfaa103fc9a33ec16d2d62569d541b79f828c382556ff072442226d1968",
+                "sha256:3673c8b2b29077f1b7b3a848794f8e11f401ba0b71c49fbd26fb40b71788b132",
+                "sha256:480fdd4dbda4dd6b638d3863da3be82873bba6d32d1fc12ea1b8486ac7b8d129",
+                "sha256:56ef7f56470c24bb67fb43dae442e946a6ce172f97c69f8d067ff8550cf782ff",
+                "sha256:5a936fd51049541d86ccdeef2833cc89a18e4d3808fe58a8abeb802665c5af93",
+                "sha256:5b6885c12784a27e957294b60f97e8b5b4174c7504665333c5e94fbf41ae5d6a",
+                "sha256:667c07063940e934287993366ad5f56766bc009017b4a0fe91dbd07960d0aba7",
+                "sha256:7ed448ff4eaffeb01094959b19cbaf998ecdee9ef9932381420d514e446601cd",
+                "sha256:8343bf67c72e09cfabfab55ad4a43ce3f6bf6e6ced7acf70f45ded9ebb425055",
+                "sha256:92feb989b47f83ebef246adabc7ff3b9a59ac30601c3f6819f8913458610bdcc",
+                "sha256:935c27ae2760c21cd7354402546f6be21d3d0c806fffe967f745d5f2de5005a7",
+                "sha256:aaf42a04b472d12515debc621c31cf16c215e332242e7a9f56403d814c744624",
+                "sha256:b12e639378c741add21fbffd16ba5ad25c0a1a17cf2b6fe4288feeb65144f35b",
+                "sha256:b1cca51512299841bf69add3b75361779962f9cee7d9ee3bb446d5982e925b69",
+                "sha256:b8456987b637232602ceb4d663cb34106f7eb780e247d51a260b84760fd8f491",
+                "sha256:b9792b0ac0130b277536ab8944e7b754c69560dac0415dd4b2dbd16b902c8954",
+                "sha256:c9591886fc9cbe5532d5df85cb8e0cc3b44ba8ce4367bd4cf1b93dc19713da72",
+                "sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7",
+                "sha256:de8b4a9b56255797cbddb93281ed92acbc510fb7b15df3f01bd28f46ebc4edae",
+                "sha256:e1b1dc0372f530f26a03578ac75d5e51b3868b9b76cd2facba4c9ee0eb252ab1",
+                "sha256:e45f8e981a0ab47103181773cc0a54e650b2aef8c7b6cd07405d0fa8d869444a",
+                "sha256:e4f6d3c53911a9d103d8ec9518190e52a8b945bab021745af4939cfc7c0d4a9e",
+                "sha256:ed8a311493cf5480a2ebc597d1e177231984c818a86875126cfd004241a73c3e",
+                "sha256:ef71a1d4fd4858596ae80ad1ec76404ad29701f8ca7cdcebc50300178db14dfc"
             ],
-            "version": "==1.19.0"
+            "version": "==1.19.1"
         },
         "pandas": {
             "hashes": [
@@ -255,6 +267,37 @@
             ],
             "version": "==1.0.5"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
+            ],
+            "version": "==7.2.0"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
@@ -268,6 +311,14 @@
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
             "version": "==2.8.1"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:debd928b49dbc2bf68040566f55cdb3252458036464806f4094487244e2a4093",
+                "sha256:f157d71d5fec9d4bd5f51c82746b6344dffa680ee85217c123f4a0c8117c4544"
+            ],
+            "index": "pypi",
+            "version": "==0.10.3"
         },
         "pytz": {
             "hashes": [
@@ -291,6 +342,13 @@
             ],
             "index": "pypi",
             "version": "==0.4.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
         },
         "sanpy": {
             "hashes": [

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+docker build -t api-test . &&
+docker run --rm -t api-test python cli.py projects bitcoin

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 docker build --build-arg PYTHON_ENV=test -t api-test . &&
-docker run --rm -t api-test python cli.py projects bitcoin
+docker run --rm -e API_KEY=$API_KEY -t api-test python cli.py projects bitcoin

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
-docker build -t api-test . &&
+docker build --build-arg PYTHON_ENV=test -t api-test . &&
 docker run --rm -t api-test python cli.py projects bitcoin

--- a/cli.py
+++ b/cli.py
@@ -12,10 +12,13 @@ from constants import DAYS_BACK_TEST, \
                       INTERVAL_FRONTEND, \
                       API_KEY,\
                       TOP_PROJECTS_BY_MARKETCAP, \
-                      HOURS_BACK_TEST_FRONTEND
+                      HOURS_BACK_TEST_FRONTEND, \
+                      LOG_FORMAT, \
+                      LOG_LEVEL, \
+                      LOG_DATE_FORMAT
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL, datefmt=LOG_DATE_FORMAT)
 
 slugs = []
 

--- a/cli.py
+++ b/cli.py
@@ -14,12 +14,14 @@ from constants import DAYS_BACK_TEST, \
                       TOP_PROJECTS_BY_MARKETCAP, \
                       HOURS_BACK_TEST_FRONTEND
 
-if API_KEY:
-    san.ApiConfig.api_key = API_KEY
 
 logging.basicConfig(level=logging.INFO)
 
 slugs = []
+
+if API_KEY:
+    logging.info('Using API key')
+    san.ApiConfig.api_key = API_KEY
 
 def frontend():
     logging.info('Testing frontend...')

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,14 @@
+[development]
+upload_to_s3 = false
+send_discord_notification = false
+build_stability_report = false
+
+[test]
+upload_to_s3 = false
+send_discord_notification = false
+build_stability_report = false
+
+[production]
+upload_to_s3 = true
+send_discord_notification = true
+build_stability_report = false

--- a/config.ini
+++ b/config.ini
@@ -3,11 +3,6 @@ upload_to_s3 = false
 send_discord_notification = false
 build_stability_report = false
 
-[test]
-upload_to_s3 = false
-send_discord_notification = false
-build_stability_report = false
-
 [production]
 upload_to_s3 = true
 send_discord_notification = true

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+from configparser import ConfigParser
+import os
+
+CONFIG_FILENAME = 'config.ini'
+
+class Config:
+    def __init__(self, env):
+        self.path = os.path.join(os.getcwd(), CONFIG_FILENAME)
+        self.env = env
+        self.config = self.__read(self.path)
+
+    def getboolean(self, key):
+        return self.config.getboolean(self.env, key)
+
+    def __read(self, path):
+        config = ConfigParser()
+        config.read(path)
+
+        return config

--- a/constants.py
+++ b/constants.py
@@ -25,6 +25,12 @@ CALL_DELAY = float(os.getenv('CALL_DELAY', 0.09))
 ERRORS_IN_ROW = int(os.getenv('ERRORS_IN_ROW', 0))
 PYTHON_ENV = os.getenv('PYTHON_ENV', 'development')
 
+LOG_FORMAT = os.getenv(
+    'LOG_FORMAT',
+    '{"level": "%(levelname)s", "time": "%(asctime)s", "message": "%(message)s"}')
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
+LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+
 METRICS_WITH_LONGER_DELAY = [
     "network_growth",
     "amount_in_top_holders",

--- a/constants.py
+++ b/constants.py
@@ -23,6 +23,8 @@ S3_BUCKET_NAME = os.getenv('S3_BUCKET_NAME', '')
 NUMBER_OF_RETRIES = os.getenv('NUMBER_OF_RETRIES', 5)
 CALL_DELAY = float(os.getenv('CALL_DELAY', 0.09))
 ERRORS_IN_ROW = int(os.getenv('ERRORS_IN_ROW', 0))
+PYTHON_ENV = os.getenv('PYTHON_ENV', 'development')
+
 METRICS_WITH_LONGER_DELAY = [
     "network_growth",
     "amount_in_top_holders",

--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,9 @@
 import os
 from datetime import timedelta as td
+from dotenv import load_dotenv
+
+load_dotenv()
+
 API_KEY = os.getenv('API_KEY')
 DT_FORMAT = os.getenv("DT_FORMAT", "%Y-%m-%d")
 DATETIME_PATTERN_METRIC = os.getenv("DATETIME_PATTERN_METRIC", "%Y-%m-%dT%H:00:00Z")
@@ -13,6 +17,9 @@ HISTOGRAM_METRICS_LIMIT = int(os.getenv('HISTOGRAM_METRICS_LIMIT', 10))
 BATCH_SIZE = int(os.getenv('BATCH_SIZE', 50))
 DISCORD_WEBHOOK = os.getenv('DISCORD_WEBHOOK')
 DISCORD_USER_ID = os.getenv('DISCORD_USER_ID')
+S3_ACCESS_KEY = os.getenv('S3_ACCESS_KEY', '')
+S3_ACCESS_SECRET = os.getenv('S3_ACCESS_SECRET', '')
+S3_BUCKET_NAME = os.getenv('S3_BUCKET_NAME', '')
 NUMBER_OF_RETRIES = os.getenv('NUMBER_OF_RETRIES', 5)
 CALL_DELAY = float(os.getenv('CALL_DELAY', 0.09))
 ERRORS_IN_ROW = int(os.getenv('ERRORS_IN_ROW', 0))

--- a/file_utils.py
+++ b/file_utils.py
@@ -1,0 +1,30 @@
+import os
+import json
+
+OUTPUT_FOLDER = './output'
+
+def save_json_to_file(output, filename):
+    create_folder_if_not_present(OUTPUT_FOLDER)
+
+    filepath = f'{OUTPUT_FOLDER}/{filename}'
+
+    with open(filepath, 'w+') as file:
+        json.dump(output, file, indent=4)
+
+    return filepath
+
+def read_json_from_file(filename):
+    with open(f'{OUTPUT_FOLDER}/{filename}', 'r') as file:
+        return json.load(file)
+
+def save_file(data, filename):
+    filepath = f'{OUTPUT_FOLDER}/{filename}'
+
+    with open(filepath, 'w+') as file:
+        file.write(data)
+
+    return filepath
+
+def create_folder_if_not_present(folder):
+    if not os.path.isdir(folder):
+        os.mkdir(folder)

--- a/html_reporter.py
+++ b/html_reporter.py
@@ -1,5 +1,6 @@
 import sys, os
 import json
+from file_utils import read_json_from_file, save_file
 
 color_mapping = {
     "passed": "PaleGreen",
@@ -13,9 +14,9 @@ color_mapping = {
     "N/A": "LightGray"
 }
 
-def generate_html_from_json(input_file, output_file=None):
-    with open(f'./output/{input_file}.json', 'r') as file:
-        data = json.load(file)
+def generate_html_from_json(input_file, output_file):
+    data = read_json_from_file(input_file)
+
     html = '''
     <!DOCTYPE html>
     <html>
@@ -83,10 +84,8 @@ def generate_html_from_json(input_file, output_file=None):
     </script>
     </body>
     </html>'''
-    if not output_file:
-        output_file = input_file
-    with open(f'./output/{output_file}.html', 'w+') as file:
-        file.write(html)
+
+    return save_file(filename = output_file, data=html)
 
 def generate_html_table_sorted(data):
     html = '<div class="content">'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests==2.22.0
 discord.py==1.2.3
 s3fs==0.4.2
 fire==0.2.1
+boto3==1.14.25
+python-dotenv==0.10.3

--- a/s3.py
+++ b/s3.py
@@ -1,0 +1,10 @@
+import boto3
+from constants import S3_ACCESS_KEY, S3_ACCESS_SECRET, S3_BUCKET_NAME
+
+def s3_bucket():
+    session = boto3.Session(aws_access_key_id=S3_ACCESS_KEY, aws_secret_access_key=S3_ACCESS_SECRET)
+    return session.resource('s3').Bucket(S3_BUCKET_NAME) # pylint: disable=E1101
+
+def upload_to_s3(filepath, key):
+    bucket = s3_bucket()
+    bucket.upload_file(Filename=filepath, Key=key)


### PR DESCRIPTION
Execution of sanity tests was taking too much time and creating a lot of problems in Jenkins, move it to Airflow. Currently Jenkins will be responsible to build and publish docker image and execute sanity check only for BTC w/o html generation and publishing to S3. 

**DONE**
* move s3 publishing from Jenkins to `api_tests.py`
* clean-up Jenkinsfile - do not generate and publish HTML, do not run sanity tests
* add configuration per environment (ex. do not publish to S3 in dev env)
* use JSON for logging

**TODO**
* move frontend tests to Airflow
* stability test is disabled and broken - fix it
* we have two libs for S3 communication - `boto3` and `s3fs`, migrate to single lib

Related [PR in airflow](https://github.com/santiment/docker-airflow/pull/184)