### PR TITLE
Remove some tokens from sanity check

### DIFF
--- a/api_tests/constants.py
+++ b/api_tests/constants.py
@@ -93,25 +93,13 @@ SLUGS_FOR_SANITY_CHECK = [
     "binance-coin",
     "ethereum",
     "multi-collateral-dai",
-    "aave",
     "basic-attention-token",
     "chainlink",
-    "enjin-coin",
     "0x",
-    "rlc",
-    "omisego",
-    "crypto-com-coin",
-    "decentraland",
-    "nexo",
-    "matic-network",
     "synthetix-network-token",
     "kyber-network",
     "augur",
-    "golem-network-tokens",
-    "crypto-com",
-    "ren",
-    "maker",
-    "status"
+    "maker"
 ]
 
 LEGACY_ASSET_SLUGS = [


### PR DESCRIPTION
Builds are frequently running for more than an hour, removing some
assets will speed-up builds.