### PR TITLE
Add Debug view

### DIFF
--- a/api_tests/api_helper.py
+++ b/api_tests/api_helper.py
@@ -190,7 +190,3 @@ def get_min_interval(metric):
             attempts += 1
             error = e
     raise SanError(f"Not able to get min interval for {metric} after 3 attempts. Reason: {str(error)}")
-
-
-if __name__ == '__main__':
-    print(get_query_data('priceVolumeDiff', 'ethereum', dt.now() - td(days=1), dt.now(), '1d'))

--- a/api_tests/html_report.py
+++ b/api_tests/html_report.py
@@ -103,7 +103,7 @@ def generate_html_table_big_data(data):
             <tr>'''
             for value in values:
                 html += f'''
-                <th>{value['name']}</th>
+                <th><a href="{value['gql_query_url']}">{value['name']}</a></th>
                 '''
             html += '''
             </tr>
@@ -111,7 +111,9 @@ def generate_html_table_big_data(data):
             for value in values:
                 color = color_mapping[value['status'].split(':')[0]]
                 html += f'''
-                <td style="background-color:{color};text-align:center;"><a href="{value['gql_query_url']}">{value['status']}</a></td>
+                <td style="background-color:{color};text-align:center;">
+                    {''.join(value['details'])}
+                </td>
                 '''
             html += '''
             </tr>
@@ -194,7 +196,3 @@ def generate_html_table_merged(data):
     html += '</table></div>'
     return html
 
-
-
-if __name__ == '__main__':
-    generate_html_from_json('output_for_html', 'index')

--- a/api_tests/html_report.py
+++ b/api_tests/html_report.py
@@ -66,7 +66,7 @@ def generate_html_from_json(input_file, output_file):
     '''
     html += generate_html_table_sorted(data)
     html += '''
-    <button type="button" class="collapsible">Big data view</button>
+    <button type="button" class="collapsible">Debug view</button>
     '''
     html += generate_html_table_big_data(data)
     html += '''

--- a/api_tests/html_report.py
+++ b/api_tests/html_report.py
@@ -66,6 +66,10 @@ def generate_html_from_json(input_file, output_file):
     '''
     html += generate_html_table_sorted(data)
     html += '''
+    <button type="button" class="collapsible">Big data view</button>
+    '''
+    html += generate_html_table_big_data(data)
+    html += '''
     <script>
     var coll = document.getElementsByClassName("collapsible");
     var i;
@@ -86,6 +90,39 @@ def generate_html_from_json(input_file, output_file):
     </html>'''
 
     return save_file(filename = output_file, data=html)
+
+def generate_html_table_big_data(data):
+    html = '<div class="content">'
+    for item in data:
+        html += f'''<div style="text-align:left;">{item['slug'].upper()}</div>'''
+        values = list(filter(lambda value: value['status'] == 'corrupted', item['data']))
+        if values:
+            html += f'''
+            <div class="scrolly">
+            <table>
+            <tr>'''
+            for value in values:
+                html += f'''
+                <th>{value['name']}</th>
+                '''
+            html += '''
+            </tr>
+            <tr>'''
+            for value in values:
+                color = color_mapping[value['status'].split(':')[0]]
+                html += f'''
+                <td style="background-color:{color};text-align:center;"><a href="{value['gql_query_url']}">{value['status']}</a></td>
+                '''
+            html += '''
+            </tr>
+            </table>
+            </div>
+            <br/>
+            '''
+        else:
+            html += '<div><b>EMPTY</b></div><br/>'
+    html += '</div>'
+    return html
 
 def generate_html_table_sorted(data):
     html = '<div class="content">'

--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -49,7 +49,6 @@ class MetricReport:
     def error_to_json(self):
         self.error['name'] = self.name
         self.error['reason'] = self.status
-        self.error['gql_query'] = self.query
         self.error['gql_query_url'] = self.generate_gql_url()
         self.error['details'] = self.error_details
 

--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -1,6 +1,5 @@
 import urllib.parse
 from san.env_vars import SANBASE_GQL_HOST
-from .constants import IGNORED_METRICS
 
 class MetricReport:
     def __init__(self, name, slug, query):
@@ -9,6 +8,13 @@ class MetricReport:
         self.query = query
         self.status = None
         self.error = {}
+        self.error_details = []
+
+    def set_passed(self):
+        self.status = 'passed'
+
+    def set_ignored(self):
+        self.status = 'ignored'
 
     def set_empty(self):
         self.status = 'empty'
@@ -31,8 +37,9 @@ class MetricReport:
         elif self.status == 'empty' or self.status == 'corrupted':
             return 'corrupted data'
 
-    def set_error_details(self, details):
-        self.error['details'] = details
+    def append_error_details(self, error_detail):
+        self.set_corrupted()
+        self.error_details.append(error_detail)
 
     def generate_gql_url(self):
         first_part = SANBASE_GQL_HOST.replace('graphql', 'graphiql?query=')
@@ -44,23 +51,15 @@ class MetricReport:
         self.error['reason'] = self.status
         self.error['gql_query'] = self.query
         self.error['gql_query_url'] = self.generate_gql_url()
+        self.error['details'] = self.error_details
 
         return self.error
 
-    def summary_to_json(self, ignored_metrics_key):
-        json_summary = {}
-        if self.status:
-            json_summary = {
-                'name': self.name,
-                'status': self.status,
-                'gql_query_url': self.generate_gql_url()
-            }
+    def summary_to_json(self):
+        return {
+            'name': self.name,
+            'status': self.status,
+            'gql_query_url': self.generate_gql_url(),
+            'details': self.error_details
+        }
 
-            if 'details' in self.error: json_summary['details'] = self.error['details']
-        else:
-            json_summary = {'name': self.name, 'status': 'passed'}
-
-        if self.slug in IGNORED_METRICS and self.name in IGNORED_METRICS[self.slug][ignored_metrics_key]:
-            json_summary = {'name': self.name, 'status': 'ignored'}
-
-        return json_summary

--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -9,7 +9,6 @@ class MetricReport:
         self.query = query
         self.status = None
         self.error = {}
-        self.error_details = []
 
     def set_empty(self):
         self.status = 'empty'
@@ -51,7 +50,13 @@ class MetricReport:
     def summary_to_json(self, ignored_metrics_key):
         json_summary = {}
         if self.status:
-            json_summary = {'name': self.name, 'status': self.status, 'gql_query_url': self.generate_gql_url()}
+            json_summary = {
+                'name': self.name,
+                'status': self.status,
+                'gql_query_url': self.generate_gql_url()
+            }
+
+            if 'details' in self.error: json_summary['details'] = self.error['details']
         else:
             json_summary = {'name': self.name, 'status': 'passed'}
 

--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -51,7 +51,7 @@ class MetricReport:
     def summary_to_json(self, ignored_metrics_key):
         json_summary = {}
         if self.status:
-            json_summary = {'name': self.name, 'status': self.status}
+            json_summary = {'name': self.name, 'status': self.status, 'gql_query_url': self.generate_gql_url()}
         else:
             json_summary = {'name': self.name, 'status': 'passed'}
 

--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,7 @@ from datetime import timedelta as td
 import san
 from api_tests.api_tests import run, filter_projects_by_marketcap
 from api_tests.frontend import run as run_frontend_test
+from api_tests.html_report import generate_html_from_json
 from api_tests.constants import DAYS_BACK_TEST, \
                                 INTERVAL, \
                                 INTERVAL_FRONTEND, \
@@ -18,7 +19,6 @@ from api_tests.constants import DAYS_BACK_TEST, \
                                 SLUGS_FOR_SANITY_CHECK, \
                                 LEGACY_ASSET_SLUGS
 
-
 logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL, datefmt=LOG_DATE_FORMAT)
 
 slugs = []
@@ -30,23 +30,32 @@ if API_KEY:
 def frontend():
     logging.info('Testing frontend...')
     run_frontend_test(td(hours=HOURS_BACK_TEST_FRONTEND), INTERVAL_FRONTEND)
+    logging.info('Done')
 
 def sanity():
     logging.info('Doing sanity check...')
     slugs = SLUGS_FOR_SANITY_CHECK + LEGACY_ASSET_SLUGS
     logging.info(f'Slugs: {slugs}')
     run(slugs, DAYS_BACK_TEST, INTERVAL)
+    logging.info('Done')
 
 def top():
     logging.info(f'Testing top {TOP_PROJECTS_BY_MARKETCAP} projects by marketcap...')
     slugs = filter_projects_by_marketcap(TOP_PROJECTS_BY_MARKETCAP)
     logging.info(f'Slugs: {slugs}')
     run(slugs, DAYS_BACK_TEST, INTERVAL)
+    logging.info('Done')
 
 def projects(*items):
     slugs = list(items)
     logging.info(f'Slugs: {slugs}')
     run(slugs, DAYS_BACK_TEST, INTERVAL)
+    logging.info('Done')
+
+def generate_html_report():
+    logging.info('Generating HTML report...')
+    generate_html_from_json('output_for_html.json', 'index.html')
+    logging.info('Done')
 
 if __name__ == '__main__':
     fire.Fire()

--- a/tests/api_tests_test.py
+++ b/tests/api_tests_test.py
@@ -1,0 +1,20 @@
+from api_tests.api_tests import is_delay
+from datetime import datetime, timedelta
+
+def test_is_delay_when_delayed():
+    dates = [datetime(2020, 7, 6, 0, 0), datetime(2020, 7, 7, 0, 0)]
+    accepted_delay = datetime(2020, 7, 9, 0, 0) - timedelta(hours=24)
+
+    (is_delayed, delayed_since, acceptable_delayed_since) = is_delay(dates, accepted_delay)
+    assert is_delayed == True
+    assert delayed_since == datetime(2020, 7, 7, 0, 0)
+    assert acceptable_delayed_since == datetime(2020, 7, 8, 0, 0)
+
+def test_is_delay_when_not_delayed():
+    dates = [datetime(2020, 7, 6, 0, 0), datetime(2020, 7, 7, 0, 0)]
+    accepted_delay = datetime(2020, 7, 8, 0, 0) - timedelta(hours=24)
+
+    (is_delayed, delayed_since, acceptable_delayed_since) = is_delay(dates, accepted_delay)
+    assert is_delayed == False
+    assert delayed_since == datetime(2020, 7, 7, 0, 0)
+    assert acceptable_delayed_since == datetime(2020, 7, 7, 0, 0)


### PR DESCRIPTION
![Screenshot from 2020-08-04 13-42-09](https://user-images.githubusercontent.com/103871/89285053-5e8d3500-d658-11ea-9445-ca3020d75835.png)

Debug view has all the metrics that are failing or empty and each metric contain link to GraphQL query and error details.
Refactoring of few functions was needed to simplify logic:
* setting of statuses is explicit 
* all statuses has the same structure:

output.json
```json
          {
                "name": "active_addresses_24h",
                "reason": "passed",
                "gql_query_url": "https://api.santiment.net/graphiql?query=%0A%20%20%20%20%7B%0A%20%20%20%20%20%20getMetric%28metric%3A%20%22active_addresses_24h%22%29%7B%0A%20%20%20%20%20%20%20%20timeseriesData%28%0A%20%20%20%20%20%20%20%20%20%20slug%3A%20%22bitcoin%22%0A%20%20%20%20%20%20%20%20%20%20from%3A%20%222020-07-05T13%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20to%3A%20%222020-08-04T13%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20includeIncompleteData%3A%20true%0A%20%20%20%20%20%20%20%20%20%20interval%3A%20%2212h%22%29%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20datetime%0A%20%20%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20",
                "details": []
            }
```
output_for_html.json
```json
            {
                "name": "active_addresses_24h",
                "status": "passed",
                "gql_query_url": "https://api.santiment.net/graphiql?query=%0A%20%20%20%20%7B%0A%20%20%20%20%20%20getMetric%28metric%3A%20%22active_addresses_24h%22%29%7B%0A%20%20%20%20%20%20%20%20timeseriesData%28%0A%20%20%20%20%20%20%20%20%20%20slug%3A%20%22bitcoin%22%0A%20%20%20%20%20%20%20%20%20%20from%3A%20%222020-07-05T13%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20to%3A%20%222020-08-04T13%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20includeIncompleteData%3A%20true%0A%20%20%20%20%20%20%20%20%20%20interval%3A%20%2212h%22%29%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20datetime%0A%20%20%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20",
                "details": []
            }
```
it can be further simplified/cleaned

Other changes:
* removed `gql_query` field from json - we don't use it and `gql_query_url` is much more practical
* renamed  **Merged view** to **Classic view**
* removed **Sorted view**
* added **Debug view**