### PR TITLE
Decouple stability report

### DIFF
--- a/api_tests/api_tests.py
+++ b/api_tests/api_tests.py
@@ -34,9 +34,11 @@ from .constants import DATETIME_PATTERN_METRIC, \
                        LEGACY_ASSET_SLUGS, \
                        IGNORED_METRICS
 
+config = Config(PYTHON_ENV)
+
 def run(slugs, days_back, interval):
     logging.info('PYTHON_ENV: %s', PYTHON_ENV)
-    config = Config(PYTHON_ENV)
+
     started = dt.utcnow()
     started_string = started.strftime("%Y-%m-%d-%H-%M")
 
@@ -85,23 +87,6 @@ def run(slugs, days_back, interval):
         logging.info('Uploaded %s', current_json_report_filename)
     else:
         logging.info("Skipping publish reports to S3")
-
-    if config.getboolean('build_stability_report'):
-        logging.info('Generating stability json report...')
-        stability_json_filepath = create_stability_report(ERRORS_IN_ROW)
-
-        if config.getboolean('upload_to_s3'):
-            latest_json_stability_report_filename = 'latest-stability-report.json'
-            upload_to_s3(filepath=stability_json_filepath, key=latest_json_stability_report_filename)
-            set_json_content_type(latest_json_stability_report_filename)
-            logging.info('Uploaded %s', latest_json_stability_report_filename)
-
-            current_json_stability_report_filename = f'{started_string}-stability-report.json'
-            upload_to_s3(filepath=stability_json_filepath, key=current_json_stability_report_filename)
-            set_json_content_type(current_json_stability_report_filename)
-            logging.info('Uploaded %s', current_json_stability_report_filename)
-    else:
-        logging.info("Skipping generation of stability report")
 
     logging.info('Finished')
 

--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -29,7 +29,7 @@ class MetricReport:
         return self.error is not None and self.status == 'corrupted'
 
     def has_errors(self):
-        return bool(self.status)
+        return False if self.status in ['passed', 'ignored'] else True
 
     def error_output(self):
         if self.status == 'GraphQL error':

--- a/cli.py
+++ b/cli.py
@@ -7,6 +7,8 @@ import san
 from api_tests.api_tests import run, filter_projects_by_marketcap
 from api_tests.frontend import run as run_frontend_test
 from api_tests.html_report import generate_html_from_json
+from api_tests.stability_report import run as run_stability_report
+from api_tests.config import Config
 from api_tests.constants import DAYS_BACK_TEST, \
                                 INTERVAL, \
                                 INTERVAL_FRONTEND, \
@@ -17,9 +19,11 @@ from api_tests.constants import DAYS_BACK_TEST, \
                                 LOG_LEVEL, \
                                 LOG_DATE_FORMAT, \
                                 SLUGS_FOR_SANITY_CHECK, \
-                                LEGACY_ASSET_SLUGS
+                                LEGACY_ASSET_SLUGS, \
+                                PYTHON_ENV
 
 logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL, datefmt=LOG_DATE_FORMAT)
+config = Config(PYTHON_ENV)
 
 slugs = []
 
@@ -39,6 +43,16 @@ def sanity():
     slugs = SLUGS_FOR_SANITY_CHECK + LEGACY_ASSET_SLUGS
     logging.info(f'Slugs: {slugs}')
     run(slugs, DAYS_BACK_TEST, INTERVAL)
+    logging.info('Done')
+
+def build_stability_report():
+    """Do a stability report based on the last X reports uploaded in S3"""
+    if config.getboolean('build_stability_report'):
+        logging.info('Generating stability json report...')
+        run_stability_report()
+    else:
+        logging.info("Skipping generation of stability report")
+
     logging.info('Done')
 
 def top():
@@ -68,5 +82,6 @@ if __name__ == '__main__':
       'sanity': sanity,
       'top': top,
       'projects': projects,
-      'generate_html_report': generate_html_report
+      'generate_html_report': generate_html_report,
+      'build_stability_report': build_stability_report
   })


### PR DESCRIPTION
That way we can create stability report as a separate step, not only after sanity check report.