### PR TITLE
Fix names of rolling change metrics

### DIFF
--- a/api_tests/constants.py
+++ b/api_tests/constants.py
@@ -101,12 +101,12 @@ METRICS_WITH_ALLOWED_NEGATIVES = [
     "dormant_circulation_365d_change_1d",
     "dormant_circulation_365d_change_7d",
     "dormant_circulation_365d_change_30d",
-    "stack_circulation_180d_change_1d",
-    "stack_circulation_180d_change_7d",
-    "stack_circulation_180d_change_30d",
-    "stack_circulation_20y_change_1d",
-    "stack_circulation_20y_change_7d",
-    "stack_circulation_20y_change_30d",
+    "circulation_180d_change_1d",
+    "circulation_180d_change_7d",
+    "circulation_180d_change_30d",
+    "circulation_change_1d",
+    "circulation_change_7d",
+    "circulation_change_30d",
     "bitmex_perpetual_funding_rate_change_1d",
     "bitmex_perpetual_funding_rate_change_7d",
     "bitmex_perpetual_funding_rate_change_30d",
@@ -119,9 +119,9 @@ METRICS_WITH_ALLOWED_NEGATIVES = [
     "mvrv_usd_365d_change_1d",
     "mvrv_usd_365d_change_7d",
     "mvrv_usd_365d_change_30d",
-    "mvrv_usd_20y_change_1d",
-    "mvrv_usd_20y_change_7d",
-    "mvrv_usd_20y_change_30d"
+    "mvrv_usd_change_1d",
+    "mvrv_usd_change_7d",
+    "mvrv_usd_change_30d"
 ]
 
 METRICS_WITH_ALLOWED_GAPS = [


### PR DESCRIPTION
In the [previous PR](https://github.com/santiment/api-tests/pull/93) I added new change metrics, but specified their names as in CH, but need as in sanbase.