### PR TITLE
Bring back query in json output

### DIFF
--- a/api_tests/metric_report.py
+++ b/api_tests/metric_report.py
@@ -66,6 +66,7 @@ class MetricReport:
         return {
             'name': self.name,
             'status': self.status,
+            'gql_query': self.query,
             'gql_query_url': self.generate_gql_url(),
             'elapsed_time': self.elapsed_time,
             'details': self.error_details,


### PR DESCRIPTION
```json
{
  "name": "social_active_users",
  "status": "GraphQL error",
  "gql_query": "\n    {\n      getMetric(metric: \"social_active_users\"){\n        timeseriesData(\n          slug: \"bitcoin\"\n          from: \"2020-08-04T12:00:00Z\"\n          to: \"2020-09-03T12:00:00Z\"\n          includeIncompleteData: true\n          interval: \"12h\"){\n            datetime\n            value\n          }\n      }\n    }\n    ",
  "gql_query_url": "https://api-stage.santiment.net/graphiql?query=%0A%20%20%20%20%7B%0A%20%20%20%20%20%20getMetric%28metric%3A%20%22social_active_users%22%29%7B%0A%20%20%20%20%20%20%20%20timeseriesData%28%0A%20%20%20%20%20%20%20%20%20%20slug%3A%20%22bitcoin%22%0A%20%20%20%20%20%20%20%20%20%20from%3A%20%222020-08-04T12%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20to%3A%20%222020-09-03T12%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20includeIncompleteData%3A%20true%0A%20%20%20%20%20%20%20%20%20%20interval%3A%20%2212h%22%29%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20datetime%0A%20%20%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20",
  "elapsed_time": 0.0,
  "details": [],
  "performance_result": "N/A"
}
```
`query` field was removed because we have `gql_query_url` and it is more useful. 
However in case when server returns [error 500](https://api.santiment.net/graphiql?query=%0A%20%20%20%20%7B%0A%20%20%20%20%20%20getMetric%28metric%3A%20%22social_active_users%22%29%7B%0A%20%20%20%20%20%20%20%20timeseriesData%28%0A%20%20%20%20%20%20%20%20%20%20slug%3A%20%22bitcoin%22%0A%20%20%20%20%20%20%20%20%20%20from%3A%20%222020-08-04T11%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20to%3A%20%222020-09-03T11%3A00%3A00Z%22%0A%20%20%20%20%20%20%20%20%20%20includeIncompleteData%3A%20true%0A%20%20%20%20%20%20%20%20%20%20interval%3A%20%2212h%22%29%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20datetime%0A%20%20%20%20%20%20%20%20%20%20%20%20value%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20), it does not render `graphiql` and we don't have query that we can easily debug. 